### PR TITLE
Add static OCR site

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,88 @@
-# Default-
+# OCR Utility
+
+This repository contains a simple command line tool for performing OCR (Optical Character Recognition) on an image. The tool allows you to optionally transform the image (invert colors, mirror horizontally, flip vertically or rotate) before OCR. After recognizing the text, it prints each character together with its Unicode name. Optionally the text can be translated to another language using Google Translate.
+
+## Requirements
+
+- Python 3
+- Tesseract OCR installed on your system (`sudo apt-get install tesseract-ocr` on Debian/Ubuntu)
+- Python packages in `requirements.txt`
+
+## Installation
+
+```
+pip install -r requirements.txt
+```
+
+## Usage
+
+```
+python ocr_app.py IMAGE_PATH [options]
+```
+
+Options:
+
+- `--invert` – invert the image colors.
+- `--mirror` – mirror (flip horizontally) the image.
+- `--flip-vertical` – flip the image vertically.
+- `--rotate {90,180,270}` – rotate the image by the given degrees.
+- `--lang CODE` – language code used by Tesseract. Defaults to `eng`.
+- `--translate-to CODE` – language code to translate the recognized text to.
+- `--romanize` – transliterate the OCR result to Latin characters. Currently
+  supports Cyrillic (e.g. Russian), Georgian and Coptic.
+
+Characters from several specialist alphabets and symbol sets receive extra
+context. When recognised, Ogham, Deseret, basic IPA letters, Alchemical signs,
+a few hobo symbols and regular Latin letters or digits will display their
+traditional names or the equivalent Morse code.
+
+Example:
+
+```
+python ocr_app.py sample.png --invert --lang rus --translate-to en --romanize
+```
+
+This will invert `sample.png`, run OCR using the Russian language model, list all characters with their names, transliterate the text to Latin characters and translate the result into English.
+
+## Web Interface
+
+A simple Flask web app is provided for those who prefer a browser-based
+interface. Start it with:
+
+```bash
+python web_app.py
+```
+
+Then open `http://localhost:5000` in your browser. Upload an image, choose the
+transformations and languages, and view the OCR results directly on the page.
+Check the *Romanize* box if you want the text transliterated to Latin characters.
+The processed image preview will also be displayed alongside the extracted text.
+
+## Additional Alphabets
+
+The OCR output lists each recognised character together with its Unicode name
+and, when possible, extra context:
+
+- Latin letters and digits show their Morse code.
+- Characters from the Ogham and Deseret alphabets display their traditional
+  name and Latin equivalent.
+- Several Alchemical and hobo signs include a short description.
+- Basic IPA letters show a brief phonetic description.
+
+## GitHub Pages
+
+A simplified browser-only version of the OCR tool lives in the `docs/`
+folder. It uses Tesseract.js to perform OCR directly in the browser so
+no server is required.
+
+To publish the site on GitHub Pages:
+
+1. Push this repository to GitHub.
+2. Open the project on GitHub and click **Settings**.
+3. Select **Pages** from the sidebar.
+4. Under **Build and deployment** choose the `docs/` folder on the
+   `main` branch as the source.
+5. Save. GitHub will display a URL that follows the pattern
+   `https://<username>.github.io/<repo>/`.
+
+After a minute or two the static OCR page will be live at that address.

--- a/docs/app.js
+++ b/docs/app.js
@@ -1,0 +1,246 @@
+const form = document.getElementById('ocr-form');
+const canvas = document.getElementById('canvas');
+const ctx = canvas.getContext('2d');
+
+const MORSE_CODE = {
+    'A': '.-', 'B': '-...', 'C': '-.-.', 'D': '-..', 'E': '.', 'F': '..-.',
+    'G': '--.', 'H': '....', 'I': '..', 'J': '.---', 'K': '-.-', 'L': '.-..',
+    'M': '--', 'N': '-.', 'O': '---', 'P': '.--.', 'Q': '--.-', 'R': '.-.',
+    'S': '...', 'T': '-', 'U': '..-', 'V': '...-', 'W': '.--', 'X': '-..-',
+    'Y': '-.--', 'Z': '--..',
+    '0': '-----', '1': '.----', '2': '..---', '3': '...--', '4': '....-',
+    '5': '.....', '6': '-....', '7': '--...', '8': '---..', '9': '----.'
+};
+
+const OGHAM_MAP = {
+    '\u1681': ['B', 'Beith'], '\u1682': ['L', 'Luis'], '\u1683': ['F', 'Fearn'],
+    '\u1684': ['S', 'Saille'], '\u1685': ['N', 'Nion'], '\u1686': ['H', 'Uath'],
+    '\u1687': ['D', 'Dair'], '\u1688': ['T', 'Tinne'], '\u1689': ['C', 'Coll'],
+    '\u168A': ['Q', 'Ceirt'], '\u168B': ['M', 'Muin'], '\u168C': ['G', 'Gort'],
+    '\u168D': ['NG', 'nGeadal'], '\u168E': ['Z', 'Straif'], '\u168F': ['R', 'Ruis'],
+    '\u1690': ['A', 'Ailm'], '\u1691': ['O', 'Onn'], '\u1692': ['U', 'Ur'],
+    '\u1693': ['E', 'Eadhadh'], '\u1694': ['I', 'Idad']
+};
+
+const DESERET_MAP = {
+    '\u10400': 'EE', '\u10401': 'EE', '\u10402': 'AH', '\u10403': 'AH',
+    '\u10404': 'O',  '\u10405': 'O',  '\u10406': 'OO', '\u10407': 'OO'
+};
+
+const ALCHEMY_MAP = {
+    '\u1F701': 'Air', '\u1F702': 'Fire', '\u1F703': 'Water', '\u1F704': 'Earth',
+    '\u1F705': 'Arsenic', '\u1F706': 'Realgar', '\u1F707': 'Borax', '\u1F708': 'Sublimate'
+};
+
+const IPA_MAP = {
+    '\u00F0': 'eth (voiced dental fricative)',
+    '\u03B8': 'theta (voiceless dental fricative)',
+    '\u0283': 'esh (voiceless postalveolar fricative)',
+    '\u0292': 'ezh (voiced postalveolar fricative)',
+    '\u014B': 'eng (velar nasal)',
+    '\u00E6': 'ash (near-open front vowel)'
+};
+
+const HOBO_MAP = {
+    '\u2691': 'Safe place',
+    '\u2714': 'Work available'
+};
+
+const COP_TRANSLIT = {
+    '\u2C80': 'a', '\u2C81': 'a',
+    '\u2C82': 'b', '\u2C83': 'b',
+    '\u2C84': 'g', '\u2C85': 'g',
+    '\u2C86': 'd', '\u2C87': 'd',
+    '\u2C88': 'e', '\u2C89': 'e',
+    '\u2C8A': 's', '\u2C8B': 's',
+    '\u2C8C': 'z', '\u2C8D': 'z',
+    '\u2C8E': 'h', '\u2C8F': 'h',
+    '\u2C90': 'th','\u2C91': 'th',
+    '\u2C92': 'i', '\u2C93': 'i',
+    '\u2C94': 'k', '\u2C95': 'k',
+    '\u2C96': 'l', '\u2C97': 'l',
+    '\u2C98': 'm', '\u2C99': 'm',
+    '\u2C9A': 'n', '\u2C9B': 'n',
+    '\u2C9C': 'x', '\u2C9D': 'x',
+    '\u2C9E': 'o', '\u2C9F': 'o',
+    '\u2CA0': 'p', '\u2CA1': 'p',
+    '\u2CA2': 'r', '\u2CA3': 'r',
+    '\u2CA4': 's', '\u2CA5': 's',
+    '\u2CA6': 't', '\u2CA7': 't',
+    '\u2CA8': 'u', '\u2CA9': 'u',
+    '\u2CAA': 'f', '\u2CAB': 'f',
+    '\u2CAC': 'kh','\u2CAD': 'kh',
+    '\u2CAE': 'ps','\u2CAF': 'ps',
+    '\u2CB0': 'o', '\u2CB1': 'o'
+};
+
+function getExtraInfo(ch) {
+    if (MORSE_CODE[ch.toUpperCase()]) {
+        return `Morse ${MORSE_CODE[ch.toUpperCase()]}`;
+    }
+    if (OGHAM_MAP[ch]) {
+        const [latin, name] = OGHAM_MAP[ch];
+        return `Ogham ${name} -> ${latin}`;
+    }
+    if (DESERET_MAP[ch]) {
+        return `Deseret ${DESERET_MAP[ch]}`;
+    }
+    if (ALCHEMY_MAP[ch]) {
+        return `Alchemy ${ALCHEMY_MAP[ch]}`;
+    }
+    if (IPA_MAP[ch]) {
+        return `IPA ${IPA_MAP[ch]}`;
+    }
+    if (HOBO_MAP[ch]) {
+        return `Hobo ${HOBO_MAP[ch]}`;
+    }
+    return null;
+}
+
+const CYRILLIC_TO_LATIN = {
+    '\u0410':'A','\u0430':'a','\u0411':'B','\u0431':'b','\u0412':'V','\u0432':'v',
+    '\u0413':'G','\u0433':'g','\u0414':'D','\u0434':'d','\u0415':'E','\u0435':'e',
+    '\u0401':'Yo','\u0451':'yo','\u0416':'Zh','\u0436':'zh','\u0417':'Z','\u0437':'z',
+    '\u0418':'I','\u0438':'i','\u0419':'Y','\u0439':'y','\u041A':'K','\u043A':'k',
+    '\u041B':'L','\u043B':'l','\u041C':'M','\u043C':'m','\u041D':'N','\u043D':'n',
+    '\u041E':'O','\u043E':'o','\u041F':'P','\u043F':'p','\u0420':'R','\u0440':'r',
+    '\u0421':'S','\u0441':'s','\u0422':'T','\u0442':'t','\u0423':'U','\u0443':'u',
+    '\u0424':'F','\u0444':'f','\u0425':'Kh','\u0445':'kh','\u0426':'Ts','\u0446':'ts',
+    '\u0427':'Ch','\u0447':'ch','\u0428':'Sh','\u0448':'sh','\u0429':'Shch','\u0449':'shch',
+    '\u042B':'Y','\u044B':'y','\u042D':'E','\u044D':'e','\u042E':'Yu','\u044E':'yu',
+    '\u042F':'Ya','\u044F':'ya'
+};
+
+const GEORGIAN_TO_LATIN = {
+    '\u10D0':'a','\u10D1':'b','\u10D2':'g','\u10D3':'d','\u10D4':'e','\u10D5':'v',
+    '\u10D6':'z','\u10D7':'t','\u10D8':'i','\u10D9':'k','\u10DA':'l','\u10DB':'m',
+    '\u10DC':'n','\u10DD':'o','\u10DE':'p','\u10DF':'zh','\u10E0':'r','\u10E1':'s',
+    '\u10E2':'t','\u10E3':'u','\u10E4':'ph','\u10E5':'q','\u10E6':'gh','\u10E7':'sh',
+    '\u10E8':'ch','\u10E9':'ts','\u10EA':'dz','\u10EB':'ts','\u10EC':'ch','\u10ED':'kh',
+    '\u10EE':'j','\u10EF':'h','\u10F0':'e','\u10F1':'oe','\u10F2':'fi','\u10F3':'yn',
+    '\u10F4':'el','\u10F5':'har','\u10F6':'hoe','\u10F7':'hie','\u10F8':'we',
+    '\u10F9':'har','\u10FA':'hoe'
+};
+
+function romanize(text, lang) {
+    if (!lang) return text;
+    if (lang.startsWith('ru') || lang.startsWith('cyr')) {
+        return text.split('').map(ch => CYRILLIC_TO_LATIN[ch] || ch).join('');
+    }
+    if (lang.startsWith('ka')) {
+        return text.split('').map(ch => GEORGIAN_TO_LATIN[ch] || ch).join('');
+    }
+    if (lang.startsWith('cop')) {
+        return text.split('').map(ch => COP_TRANSLIT[ch] || ch).join('');
+    }
+    return text;
+}
+
+const UNICODE_NAMES = {
+    '!':'EXCLAMATION MARK', '"':'QUOTATION MARK', '#':'NUMBER SIGN', '$':'DOLLAR SIGN',
+    '%':'PERCENT SIGN', '&':'AMPERSAND', '\'':'APOSTROPHE', '(':'LEFT PARENTHESIS',
+    ')':'RIGHT PARENTHESIS', '*':'ASTERISK', '+':'PLUS SIGN', ',':'COMMA', '-':'HYPHEN-MINUS',
+    '.':'FULL STOP', '/':'SOLIDUS', ':':'COLON', ';':'SEMICOLON', '<':'LESS-THAN SIGN',
+    '=':'EQUALS SIGN', '>':'GREATER-THAN SIGN', '?':'QUESTION MARK', '@':'COMMERCIAL AT',
+    '[':'LEFT SQUARE BRACKET', '\\':'REVERSE SOLIDUS', ']':'RIGHT SQUARE BRACKET',
+    '^':'CIRCUMFLEX ACCENT', '_':'LOW LINE', '`':'GRAVE ACCENT', '{':'LEFT CURLY BRACKET',
+    '|':'VERTICAL LINE', '}':'RIGHT CURLY BRACKET', '~':'TILDE'
+};
+
+function getCharName(ch) {
+    if (/[A-Z]/.test(ch)) return `LATIN CAPITAL LETTER ${ch}`;
+    if (/[a-z]/.test(ch)) return `LATIN SMALL LETTER ${ch.toUpperCase()}`;
+    if (/[0-9]/.test(ch)) return `DIGIT ${ch}`;
+    if (UNICODE_NAMES[ch]) return UNICODE_NAMES[ch];
+    return 'UNKNOWN';
+}
+
+function getCharInfo(text) {
+    const lines = [];
+    for (const ch of text) {
+        if (ch.trim() === '') continue;
+        const name = getCharName(ch);
+        const extra = getExtraInfo(ch);
+        if (extra) {
+            lines.push(`${ch} - ${name} (${extra})`);
+        } else {
+            lines.push(`${ch} - ${name}`);
+        }
+    }
+    return lines;
+}
+
+function loadImage(file) {
+    return new Promise((resolve, reject) => {
+        const img = new Image();
+        img.onload = () => resolve(img);
+        img.onerror = reject;
+        img.src = URL.createObjectURL(file);
+    });
+}
+
+function invertPixels() {
+    const imgData = ctx.getImageData(0, 0, canvas.width, canvas.height);
+    const data = imgData.data;
+    for (let i = 0; i < data.length; i += 4) {
+        data[i] = 255 - data[i];
+        data[i+1] = 255 - data[i+1];
+        data[i+2] = 255 - data[i+2];
+    }
+    ctx.putImageData(imgData, 0, 0);
+}
+
+async function process(file, options) {
+    const img = await loadImage(file);
+    canvas.width = img.width;
+    canvas.height = img.height;
+
+    ctx.save();
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    ctx.translate(canvas.width/2, canvas.height/2);
+    if (options.rotate) {
+        ctx.rotate(options.rotate * Math.PI / 180);
+    }
+    ctx.scale(options.mirror ? -1 : 1, options.flipVertical ? -1 : 1);
+    ctx.drawImage(img, -img.width/2, -img.height/2);
+    ctx.restore();
+    if (options.invert) invertPixels();
+
+    const { data: { text } } = await Tesseract.recognize(canvas, options.lang || 'eng');
+    document.getElementById('result').textContent = text;
+
+    if (options.romanize) {
+        const roman = romanize(text, options.lang || '');
+        if (roman !== text) {
+            document.getElementById('romanized-block').style.display = 'block';
+            document.getElementById('romanized').textContent = roman;
+        }
+    }
+
+    const info = getCharInfo(text);
+    const ul = document.getElementById('char-info');
+    ul.innerHTML = '';
+    info.forEach(line => {
+        const li = document.createElement('li');
+        li.textContent = line;
+        ul.appendChild(li);
+    });
+
+    document.getElementById('processed').src = canvas.toDataURL();
+    document.getElementById('output').style.display = 'block';
+}
+
+form.addEventListener('submit', (e) => {
+    e.preventDefault();
+    const file = document.getElementById('image').files[0];
+    if (!file) return;
+    const options = {
+        invert: document.getElementById('invert').checked,
+        mirror: document.getElementById('mirror').checked,
+        flipVertical: document.getElementById('flip_vertical').checked,
+        rotate: parseInt(document.getElementById('rotate').value || '0', 10),
+        lang: document.getElementById('lang').value || 'eng',
+        romanize: document.getElementById('romanize').checked
+    };
+    process(file, options);
+});

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>OCR Utility</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <h1>OCR Utility</h1>
+    <form id="ocr-form">
+        <label>Image: <input type="file" id="image" required></label><br>
+        <label><input type="checkbox" id="invert"> Invert</label>
+        <label><input type="checkbox" id="mirror"> Mirror</label>
+        <label><input type="checkbox" id="flip_vertical"> Flip Vertical</label>
+        <label>Rotate:
+            <select id="rotate">
+                <option value="0">0</option>
+                <option value="90">90</option>
+                <option value="180">180</option>
+                <option value="270">270</option>
+            </select>
+        </label>
+        <label>OCR language: <input type="text" id="lang" value="eng"></label>
+        <label><input type="checkbox" id="romanize"> Romanize</label>
+        <button type="submit">Process</button>
+    </form>
+
+    <div id="output" style="display:none;">
+        <h2>OCR Result</h2>
+        <pre id="result"></pre>
+        <div id="romanized-block" style="display:none;">
+            <h3>Romanized</h3>
+            <pre id="romanized"></pre>
+        </div>
+        <h3>Character Names</h3>
+        <ul id="char-info"></ul>
+        <h3>Processed Image</h3>
+        <img id="processed" alt="Processed image" />
+    </div>
+
+    <canvas id="canvas" style="display:none;"></canvas>
+
+    <script src="https://cdn.jsdelivr.net/npm/tesseract.js@2.1.4/dist/tesseract.min.js"></script>
+    <script src="app.js"></script>
+</body>
+</html>

--- a/docs/style.css
+++ b/docs/style.css
@@ -1,0 +1,3 @@
+body { font-family: Arial, sans-serif; margin: 2em; }
+label { margin-right: 1em; }
+pre { background: #f4f4f4; padding: 1em; }

--- a/ocr_app.py
+++ b/ocr_app.py
@@ -1,0 +1,208 @@
+import argparse
+import unicodedata
+from PIL import Image, ImageOps
+import pytesseract
+from googletrans import Translator
+from transliterate import translit, get_available_language_codes
+
+# Additional mappings for various symbol sets
+MORSE_CODE = {
+    'A': '.-', 'B': '-...', 'C': '-.-.', 'D': '-..', 'E': '.', 'F': '..-.',
+    'G': '--.', 'H': '....', 'I': '..', 'J': '.---', 'K': '-.-', 'L': '.-..',
+    'M': '--', 'N': '-.', 'O': '---', 'P': '.--.', 'Q': '--.-', 'R': '.-.',
+    'S': '...', 'T': '-', 'U': '..-', 'V': '...-', 'W': '.--', 'X': '-..-',
+    'Y': '-.--', 'Z': '--..',
+    '0': '-----', '1': '.----', '2': '..---', '3': '...--', '4': '....-',
+    '5': '.....', '6': '-....', '7': '--...', '8': '---..', '9': '----.',
+}
+
+# Ogham letters with Latin equivalents and traditional names
+OGHAM_MAP = {
+    'ᚁ': ('B', 'Beith'), 'ᚂ': ('L', 'Luis'), 'ᚃ': ('F', 'Fearn'),
+    'ᚄ': ('S', 'Saille'), 'ᚅ': ('N', 'Nion'), 'ᚆ': ('H', 'Uath'),
+    'ᚇ': ('D', 'Dair'), 'ᚈ': ('T', 'Tinne'), 'ᚉ': ('C', 'Coll'),
+    'ᚊ': ('Q', 'Ceirt'), 'ᚋ': ('M', 'Muin'), 'ᚌ': ('G', 'Gort'),
+    'ᚍ': ('NG', 'nGeadal'), 'ᚎ': ('Z', 'Straif'), 'ᚏ': ('R', 'Ruis'),
+    'ᚐ': ('A', 'Ailm'), 'ᚑ': ('O', 'Onn'), 'ᚒ': ('U', 'Ur'),
+    'ᚓ': ('E', 'Eadhadh'), 'ᚔ': ('I', 'Idad'),
+}
+
+# A small subset of Deseret alphabet mapping
+DESERET_MAP = {
+    '𐐀': 'EE', '𐐁': 'EE', '𐐂': 'AH', '𐐃': 'AH',
+    '𐐄': 'O', '𐐅': 'O', '𐐆': 'OO', '𐐇': 'OO',
+}
+
+# Some alchemical symbols and their meanings
+ALCHEMY_MAP = {
+    '🜁': 'Air', '🜂': 'Fire', '🜃': 'Water', '🜄': 'Earth',
+    '🜅': 'Arsenic', '🜆': 'Realgar', '🜇': 'Borax', '🜈': 'Sublimate',
+}
+
+# Basic IPA letters with description
+IPA_MAP = {
+    'ð': 'eth (voiced dental fricative)',
+    'θ': 'theta (voiceless dental fricative)',
+    'ʃ': 'esh (voiceless postalveolar fricative)',
+    'ʒ': 'ezh (voiced postalveolar fricative)',
+    'ŋ': 'eng (velar nasal)',
+    'æ': 'ash (near-open front vowel)',
+}
+
+# Placeholder for a few common hobo sign approximations (not standardized)
+HOBO_MAP = {
+    '⚑': 'Safe place',
+    '✔': 'Work available',
+}
+
+
+def get_extra_info(ch):
+    """Return additional information about a character if available."""
+    # Morse code for latin letters and digits
+    if ch.upper() in MORSE_CODE:
+        return f"Morse {MORSE_CODE[ch.upper()]}"
+    # Ogham
+    if ch in OGHAM_MAP:
+        latin, name = OGHAM_MAP[ch]
+        return f"Ogham {name} -> {latin}"
+    # Deseret
+    if ch in DESERET_MAP:
+        return f"Deseret {DESERET_MAP[ch]}"
+    # Alchemical symbol
+    if ch in ALCHEMY_MAP:
+        return f"Alchemy {ALCHEMY_MAP[ch]}"
+    # IPA letters
+    if ch in IPA_MAP:
+        return f"IPA {IPA_MAP[ch]}"
+    # Hobo sign approximation
+    if ch in HOBO_MAP:
+        return f"Hobo {HOBO_MAP[ch]}"
+    return None
+
+# Minimal Coptic transliteration map based on common scholarly convention
+COP_TRANSLIT = {
+    'Ⲁ': 'a', 'ⲁ': 'a',
+    'Ⲃ': 'b', 'ⲃ': 'b',
+    'Ⲅ': 'g', 'ⲅ': 'g',
+    'Ⲇ': 'd', 'ⲇ': 'd',
+    'Ⲉ': 'e', 'ⲉ': 'e',
+    'Ⲋ': 's', 'ⲋ': 's',
+    'Ⲍ': 'z', 'ⲍ': 'z',
+    'Ⲏ': 'h', 'ⲏ': 'h',
+    'Ⲑ': 'th', 'ⲑ': 'th',
+    'Ⲓ': 'i', 'ⲓ': 'i',
+    'Ⲕ': 'k', 'ⲕ': 'k',
+    'Ⲗ': 'l', 'ⲗ': 'l',
+    'Ⲙ': 'm', 'ⲙ': 'm',
+    'Ⲛ': 'n', 'ⲛ': 'n',
+    'Ⲝ': 'x', 'ⲝ': 'x',
+    'Ⲟ': 'o', 'ⲟ': 'o',
+    'Ⲡ': 'p', 'ⲡ': 'p',
+    'Ⲣ': 'r', 'ⲣ': 'r',
+    'Ⲥ': 's', 'ⲥ': 's',
+    'Ⲧ': 't', 'ⲧ': 't',
+    'Ⲩ': 'u', 'ⲩ': 'u',
+    'Ⲫ': 'f', 'ⲫ': 'f',
+    'Ⲭ': 'kh', 'ⲭ': 'kh',
+    'Ⲯ': 'ps', 'ⲯ': 'ps',
+    'Ⲱ': 'o', 'ⲱ': 'o',
+}
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="OCR with optional transformations")
+    parser.add_argument('image', help='Path to the image file')
+    parser.add_argument('--invert', action='store_true', help='Invert colors')
+    parser.add_argument('--mirror', action='store_true', help='Mirror image horizontally')
+    parser.add_argument('--flip-vertical', action='store_true', help='Flip image vertically')
+    parser.add_argument('--rotate', type=int, choices=[90, 180, 270], default=0,
+                        help='Rotate image by given degrees')
+    parser.add_argument('--lang', default='eng', help='Tesseract language code (e.g. eng, rus, ell, heb)')
+    parser.add_argument('--translate-to', dest='translate_to', default=None,
+                        help='Translate OCR text to specified language code')
+    parser.add_argument('--romanize', action='store_true',
+                        help='Transliterate output to Latin if supported')
+    return parser.parse_args()
+
+
+def transform_image(image, args):
+    if args.invert:
+        image = ImageOps.invert(image.convert('RGB'))
+    if args.mirror:
+        image = ImageOps.mirror(image)
+    if args.flip_vertical:
+        image = ImageOps.flip(image)
+    if args.rotate:
+        image = image.rotate(args.rotate, expand=True)
+    return image
+
+
+def get_char_info(text):
+    info = []
+    for ch in text:
+        if ch.strip():
+            try:
+                name = unicodedata.name(ch)
+            except ValueError:
+                name = 'UNKNOWN'
+            extra = get_extra_info(ch)
+            if extra:
+                info.append(f"{ch} - {name} ({extra})")
+            else:
+                info.append(f"{ch} - {name}")
+    return info
+
+
+def transliterate_text(text, lang):
+    """Return a Latin transliteration of text for specific languages."""
+    if lang in get_available_language_codes():
+        try:
+            return translit(text, lang, reversed=True)
+        except Exception:
+            pass
+    if lang.startswith('ru') or lang == 'cyrillic':
+        try:
+            return translit(text, 'ru', reversed=True)
+        except Exception:
+            pass
+    if lang.startswith('ka'):
+        try:
+            return translit(text, 'ka', reversed=True)
+        except Exception:
+            pass
+    if lang.startswith('cop'):
+        return ''.join(COP_TRANSLIT.get(ch, ch) for ch in text)
+    return text
+
+
+def main():
+    args = parse_args()
+    img = Image.open(args.image)
+    img = transform_image(img, args)
+
+    text = pytesseract.image_to_string(img, lang=args.lang)
+    print("OCR Result:")
+    print(text)
+
+    if args.romanize:
+        romanized = transliterate_text(text, args.lang)
+        if romanized != text:
+            print("\nRomanized:")
+            print(romanized)
+
+    print("Character names:")
+    for line in get_char_info(text):
+        print(line)
+
+    if args.translate_to:
+        translator = Translator()
+        try:
+            translation = translator.translate(text, dest=args.translate_to)
+            print(f"\nTranslation ({args.translate_to}):")
+            print(translation.text)
+        except Exception as e:
+            print("Translation failed:", e)
+
+
+if __name__ == '__main__':
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+pytesseract
+pillow
+googletrans==4.0.0rc1
+flask
+transliterate

--- a/static/style.css
+++ b/static/style.css
@@ -1,0 +1,3 @@
+body { font-family: Arial, sans-serif; margin: 2em; }
+label { margin-right: 1em; }
+pre { background: #f4f4f4; padding: 1em; }

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>OCR Web Interface</title>
+    <link rel="stylesheet" href="/static/style.css">
+</head>
+<body>
+    <h1>OCR Utility</h1>
+    <form method="post" enctype="multipart/form-data">
+        <label>Image: <input type="file" name="image" required></label><br>
+        <label><input type="checkbox" name="invert"> Invert</label>
+        <label><input type="checkbox" name="mirror"> Mirror</label>
+        <label><input type="checkbox" name="flip_vertical"> Flip Vertical</label>
+        <label>Rotate:
+            <select name="rotate">
+                <option value="0">0</option>
+                <option value="90">90</option>
+                <option value="180">180</option>
+                <option value="270">270</option>
+            </select>
+        </label>
+        <label>OCR language: <input type="text" name="lang" value="eng"></label>
+        <label>Translate to: <input type="text" name="translate_to"></label>
+        <label><input type="checkbox" name="romanize"> Romanize</label>
+        <button type="submit">Process</button>
+    </form>
+
+    {% if result %}
+    <h2>OCR Result</h2>
+    <pre>{{ result }}</pre>
+    {% if romanized %}
+    <h3>Romanized</h3>
+    <pre>{{ romanized }}</pre>
+    {% endif %}
+    <h3>Character Names</h3>
+    <ul>
+        {% for line in char_info %}
+        <li>{{ line }}</li>
+        {% endfor %}
+    </ul>
+    {% if translation %}
+    <h3>Translation</h3>
+    <pre>{{ translation }}</pre>
+    {% endif %}
+    {% if processed_image %}
+    <h3>Processed Image</h3>
+    <img src="data:image/png;base64,{{ processed_image }}" alt="Processed image"/>
+    {% endif %}
+    {% endif %}
+</body>
+</html>

--- a/web_app.py
+++ b/web_app.py
@@ -1,0 +1,55 @@
+from flask import Flask, render_template, request
+from PIL import Image
+import pytesseract
+from googletrans import Translator
+from ocr_app import transform_image, get_char_info, transliterate_text
+import base64
+import io
+
+app = Flask(__name__)
+
+@app.route('/', methods=['GET', 'POST'])
+def index():
+    result = None
+    char_info = []
+    translation = None
+    romanized = None
+    img_data = None
+    if request.method == 'POST':
+        file = request.files.get('image')
+        if file:
+            img = Image.open(file.stream)
+            # Build an args-like object
+            class Args:
+                invert = bool(request.form.get('invert'))
+                mirror = bool(request.form.get('mirror'))
+                flip_vertical = bool(request.form.get('flip_vertical'))
+                rotate = int(request.form.get('rotate') or 0)
+            args = Args()
+            img = transform_image(img, args)
+            lang = request.form.get('lang') or 'eng'
+            result = pytesseract.image_to_string(img, lang=lang)
+            char_info = get_char_info(result)
+            if request.form.get('romanize'):
+                romanized = transliterate_text(result, lang)
+            buf = io.BytesIO()
+            img.save(buf, format='PNG')
+            img_data = base64.b64encode(buf.getvalue()).decode('utf-8')
+            translate_to = request.form.get('translate_to')
+            if translate_to:
+                translator = Translator()
+                try:
+                    translation = translator.translate(result, dest=translate_to).text
+                except Exception as e:
+                    translation = f"Translation failed: {e}"
+    return render_template(
+        'index.html',
+        result=result,
+        char_info=char_info,
+        translation=translation,
+        processed_image=img_data,
+        romanized=romanized,
+    )
+
+if __name__ == '__main__':
+    app.run(debug=True)


### PR DESCRIPTION
## Summary
- create browser-based OCR in `docs/` using Tesseract.js
- copy styling and provide JS to handle transforms, OCR, romanization and character details
- document how to enable GitHub Pages with the new static site
- expand GitHub Pages setup steps in the README

## Testing
- `python -m py_compile ocr_app.py web_app.py`


------
https://chatgpt.com/codex/tasks/task_e_68834f4df3a48321a26d8217ee616061